### PR TITLE
kubernetes-operators

### DIFF
--- a/kubernetes-operators/build/Dockerfile
+++ b/kubernetes-operators/build/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10
+RUN pip install kopf kubernetes pyyaml jinja2
+COPY templates ./templates
+COPY mysql-operator.py ./mysql-operator.py
+CMD kopf run /mysql-operator.py

--- a/kubernetes-operators/build/mysql-operator.py
+++ b/kubernetes-operators/build/mysql-operator.py
@@ -1,0 +1,165 @@
+import kopf
+import yaml
+import kubernetes
+import time
+from jinja2 import Environment, FileSystemLoader
+
+
+def wait_until_job_end(jobname):
+    api = kubernetes.client.BatchV1Api()
+    job_finished = False
+    jobs = api.list_namespaced_job('default')
+    while (not job_finished) and \
+            any(job.metadata.name == jobname for job in jobs.items):
+        time.sleep(1)
+        jobs = api.list_namespaced_job('default')
+        for job in jobs.items:
+            if job.metadata.name == jobname:
+                print(f"job with {jobname}  found,wait untill end")
+                if job.status.succeeded == 1:
+                    print(f"job with {jobname}  success")
+                    job_finished = True
+
+
+def render_template(filename, vars_dict):
+    env = Environment(loader=FileSystemLoader('./templates'))
+    template = env.get_template(filename)
+    yaml_manifest = template.render(vars_dict)
+    json_manifest = yaml.safe_load(yaml_manifest)
+    return json_manifest
+
+
+def delete_success_jobs(mysql_instance_name):
+    print("start deletion")
+    api = kubernetes.client.BatchV1Api()
+    jobs = api.list_namespaced_job('default')
+    for job in jobs.items:
+        jobname = job.metadata.name
+        if (jobname == f"backup-{mysql_instance_name}-job") or \
+                (jobname == f"restore-{mysql_instance_name}-job") or \
+                    (jobname == f"password-{mysql_instance_name}-job"):
+            if job.status.succeeded == 1:
+                api.delete_namespaced_job(jobname,
+                                          'default',
+                                          propagation_policy='Background')
+
+
+@kopf.on.create('otus.homework', 'v1', 'mysqls')
+def mysql_on_create(body, spec, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+    storage_size = body['spec']['storage_size']
+
+    persistent_volume = render_template(
+        'mysql-pv.yml.j2',
+        {'name': name, 'storage_size': storage_size}
+    )
+
+    persistent_volume_claim = render_template(
+        'mysql-pvc.yml.j2',
+        {'name': name, 'storage_size': storage_size}
+    )
+    service = render_template(
+        'mysql-service.yml.j2',
+        {'name': name}
+    )
+
+    deployment = render_template('mysql-deployment.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+
+    restore_job = render_template('restore-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+
+    # kopf.append_owner_reference(persistent_volume, owner=body)
+    kopf.append_owner_reference(persistent_volume_claim, owner=body)
+    kopf.append_owner_reference(service, owner=body)
+    kopf.append_owner_reference(deployment, owner=body)
+
+    api = kubernetes.client.CoreV1Api()
+    api.create_persistent_volume(persistent_volume)
+    api.create_namespaced_persistent_volume_claim('default', persistent_volume_claim)
+    api.create_namespaced_service('default', service)
+
+    api = kubernetes.client.AppsV1Api()
+    api.create_namespaced_deployment('default', deployment)
+
+    try:
+        api = kubernetes.client.BatchV1Api()
+        api.create_namespaced_job('default', restore_job)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    try:
+        backup_pv = render_template('backup-pv.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        api.create_persistent_volume(backup_pv)
+        status_message = 'mysql-instance created without restore-job'
+    except kubernetes.client.rest.ApiException:
+        status_message = 'mysql-instance created with restore-job'
+        pass
+
+    try:
+        backup_pvc = render_template('backup-pvc.yml.j2', {'name': name})
+        api = kubernetes.client.CoreV1Api()
+        api.create_namespaced_persistent_volume_claim('default', backup_pvc)
+    except kubernetes.client.rest.ApiException:
+        pass
+
+    return {'statusMessage': status_message}
+
+
+@kopf.on.delete('otus.homework', 'v1', 'mysqls')
+def delete_object_make_backup(body, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    password = body['spec']['password']
+    database = body['spec']['database']
+
+    delete_success_jobs(name)
+
+    api = kubernetes.client.BatchV1Api()
+    backup_job = render_template('backup-job.yml.j2', {
+        'name': name,
+        'image': image,
+        'password': password,
+        'database': database})
+    api.create_namespaced_job('default', backup_job)
+    wait_until_job_end(f"backup-{name}-job")
+
+    api = kubernetes.client.CoreV1Api()
+    api.delete_persistent_volume(f"{name}-pv")
+
+    return {'message': "mysql and its children resources deleted"}
+
+
+@kopf.on.field('otus.homework', 'v1', 'mysqls', field='spec.password')
+def change_password(body, old, new, **kwargs):
+    name = body['metadata']['name']
+    image = body['spec']['image']
+    database = body['spec']['database']
+
+    if old and new:
+        api = kubernetes.client.BatchV1Api()
+        password_job = render_template('password-job.yml.j2', {
+            'name': name,
+            'image': image,
+            'old': old,
+            'new': new,
+            'database': database})
+
+        try:
+            api = kubernetes.client.BatchV1Api()
+            api.delete_namespaced_job('password-' + name + '-job', 'default', propagation_policy='Foreground')
+        except kubernetes.client.rest.ApiException:
+            pass
+
+        time.sleep(1)
+        api.create_namespaced_job('default', password_job)

--- a/kubernetes-operators/build/templates/backup-job.yml.j2
+++ b/kubernetes-operators/build/templates/backup-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: backup-{{ name }}-job
+  labels:
+    usage: backup-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: backup-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysqldump -u root -h {{ name }} -p{{ password }} {{ database }}  > /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/backup-pv.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name:  "backup-{{ name }}-pv"
+  labels:
+    pv-usage: "backup-{{ name }}"
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 1Gi
+  hostPath:
+    path: /data/pv-backup/

--- a/kubernetes-operators/build/templates/backup-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/backup-pvc.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "backup-{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: "1Gi"
+  selector:
+    matchLabels:
+      pv-usage: "backup-{{ name }}"

--- a/kubernetes-operators/build/templates/mysql-deployment.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-deployment.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ name }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ name }}
+  template:
+    metadata:
+      labels:
+        app: {{ name }}
+    spec:
+      containers:
+      - image: {{ image }}
+        name: {{ name }}
+        args:
+        - "--ignore-db-dir=lost+found"
+        env:
+        - name: MYSQL_ROOT_PASSWORD # так делать не нужно, тут лучше secret
+          value: {{ password }}
+        - name: MYSQL_DATABASE
+          value: {{ database }}
+        ports:
+        - containerPort: 3306
+          name: mysql
+        volumeMounts:
+        - name: {{ name }}-pv
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: {{ name }}-pv
+        persistentVolumeClaim:
+          claimName: {{ name }}-pvc

--- a/kubernetes-operators/build/templates/mysql-pv.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pv.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ name }}-pv
+  labels:
+    pv-usage: {{ name }}
+spec:
+  persistentVolumeReclaimPolicy: Retain
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: {{ storage_size }}
+  hostPath:
+    path: /data/{{ name }}-pv/

--- a/kubernetes-operators/build/templates/mysql-pvc.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-pvc.yml.j2
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ name }}-pvc"
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ storage_size }}
+  selector:
+    matchLabels:
+      pv-usage: {{ name }}

--- a/kubernetes-operators/build/templates/mysql-service.yml.j2
+++ b/kubernetes-operators/build/templates/mysql-service.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ name }}
+spec:
+  ports:
+  - port: 3306
+  selector:
+    app: {{ name }}
+  clusterIP: None

--- a/kubernetes-operators/build/templates/password-job.yml.j2
+++ b/kubernetes-operators/build/templates/password-job.yml.j2
@@ -1,0 +1,28 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: password-{{ name }}-job
+  labels:
+    usage: password-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: password-{{ name }}-cronjob
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup-{{ name }}
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ old }} -e \"ALTER USER root IDENTIFIED BY '{{ new }}', 'root'@'localhost' IDENTIFIED BY '{{ new }}'\""
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/build/templates/restore-job.yml.j2
+++ b/kubernetes-operators/build/templates/restore-job.yml.j2
@@ -1,0 +1,26 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  namespace: default
+  name: restore-{{ name }}-job
+spec:
+  template:
+    metadata:
+      name: restore-{{ name }}-job
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: backup
+        image: {{ image }}
+        imagePullPolicy: IfNotPresent
+        command:
+        - /bin/sh
+        - -c
+        - "mysql -u root -h {{ name }} -p{{ password }} {{ database }}< /backup-{{ name }}-pv/{{ name }}-dump.sql"
+        volumeMounts:
+        - name: backup-{{ name }}-pv
+          mountPath: /backup-{{ name }}-pv
+      volumes:
+      - name: backup-{{ name }}-pv
+        persistentVolumeClaim:
+          claimName: backup-{{ name }}-pvc

--- a/kubernetes-operators/deploy/ClusterRoleBinding.yaml
+++ b/kubernetes-operators/deploy/ClusterRoleBinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: workshop-operator
+subjects:
+- kind: ServiceAccount
+  name: mysql-operator
+  namespace: default
+roleRef:
+  kind: ClusterRole
+  name: mysql-operator
+  apiGroup: rbac.authorization.k8s.io

--- a/kubernetes-operators/deploy/cr.yaml
+++ b/kubernetes-operators/deploy/cr.yaml
@@ -1,0 +1,9 @@
+apiVersion: otus.homework/v1
+kind: MySQL
+metadata:
+  name: mysql-instance
+spec:
+  image: mysql:5.7
+  database: otus-database
+  password: otuspassword1
+  storage_size: 1Gi

--- a/kubernetes-operators/deploy/crd.yaml
+++ b/kubernetes-operators/deploy/crd.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: mysqls.otus.homework # имя CRD должно иметь формат plural.group
+spec:
+  scope: Namespaced     # Данный CRD будер работать в рамках namespace
+  group: otus.homework  # Группа, отражается в поле apiVersion CR
+  versions:             # Список версий
+    - name: v1
+      served: true      # Будет ли обслуживаться API-сервером данная версия
+      storage: true     # Фиксирует  версию описания, которая будет сохраняться в etcd
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              required: ["image", "database", "password", "storage_size"]
+              properties:
+                image:
+                  type: string
+                database:
+                  type: string
+                password:
+                  type: string
+                storage_size:
+                  type: string
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+      subresources:
+        status: { }
+  names:                # различные форматы имени объекта CR
+    kind: MySQL         # kind CR
+    plural: mysqls
+    singular: mysql
+    shortNames:
+      - ms

--- a/kubernetes-operators/deploy/deploy-operator.yaml
+++ b/kubernetes-operators/deploy/deploy-operator.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mysql-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: mysql-operator
+  template:
+    metadata:
+      labels:
+        name: mysql-operator
+    spec:
+      serviceAccountName: mysql-operator
+      containers:
+        - name: operator
+          image: mozart89/mysql-operator:v0.0.6
+          imagePullPolicy: "Always"

--- a/kubernetes-operators/deploy/role.yaml
+++ b/kubernetes-operators/deploy/role.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: mysql-operator
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - '*'

--- a/kubernetes-operators/deploy/service-account.yaml
+++ b/kubernetes-operators/deploy/service-account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mysql-operator


### PR DESCRIPTION
# Выполнено ДЗ № 7

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
 - создана ветка **kubernetes-operators** и директория **kubernetes-operators**
 - добавлена субдиректория **kubernetes-operators/build** с файлами
 - добавлена субдиректория **kubernetes-operators/deploy** с файлами

## Как запустить проект:
 - перейти в директорию **cd kubernetes-operators**
 - запустить команду **kubectl apply -f deploy/crd.yaml**
 - запустить команду **kubectl apply -f deploy**
 - запустить команды :
 ```
 export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
kubectl exec -it $MYSQLPOD -- mysql -u root -potuspassword -e "CREATE TABLE test (id smallint unsigned not null auto_increment, name varchar(20) not null, constraint pk_example primary key (id) );" otus-database
kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name) VALUES ( null, 'some data' );" otus-database
kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "INSERT INTO test ( id, name)VALUES ( null, 'some data-2' );" otus-database
kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
 ```

## Как проверить работоспособность:
 - проверить 
 - запустить команды :
```
export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
kubectl exec -it $MYSQLPOD -- mysql -potuspassword1 -e "select * from test;" otus-database
```
 - получить результат
```
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+
```
- удалить CR командой **kubectl delete mysqls.otus.homework mysql-instance**
- дождаться окончания резервного копирования командой **kubectl get jobs.batch backup-mysql-instance-job** :
```
NAME                        COMPLETIONS   DURATION   AGE
backup-mysql-instance-job   1/1           5s         84m
```
 - создать CR командой k**ubectl apply -f deploy/cr.yaml**
 - дождаться окончания восстановления командой **kubectl get jobs.batch restore-mysql-instance-job** :
 ```
 NAME                         COMPLETIONS   DURATION   AGE
restore-mysql-instance-job   1/1           51s        75m
 ```
 - проверить данные командами :
 ```
 export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
 kubectl exec -it $MYSQLPOD -- mysql -potuspassword -e "select * from test;" otus-database
 ```
  - получить результат :
  ```
  +----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
+----+-------------+
  ```
  
## Задание (*) 1

Добавлен код:
1. В **CRD** в **properties** добавлен:
```
            status:
              type: object # добавлено поле status
              x-kubernetes-preserve-unknown-fields: true # добавлена возможность добавлять произвольные поля
```
2. В **CRD** в первый элемент списка **versions** добавлены свойства :
```
      subresources:
        status: { } # включаем статус
```
3. В **mysql-operator.py** обновлён блок создания PersistentVolume и добавлено возвращение результата **mysql_on_create** :
```
    try:
        backup_pv = render_template('backup-pv.yml.j2', {'name': name})
        api = kubernetes.client.CoreV1Api()
        api.create_persistent_volume(backup_pv)
        status_message = 'mysql-instance created without restore-job'
    except kubernetes.client.rest.ApiException:
        status_message = 'mysql-instance created with restore-job'
        pass
...
    return {'statusMessage': status_message}
```
4. После первого создания CR в описании появится запись вида:
```
Status:
  Kopf:
    Progress:
  mysql_on_create:
    Status Message:  mysql-instance created without restore-job
```
5. После последующего создания CR в описании появится запись вида:
```
Status:
  Kopf:
    Progress:
  mysql_on_create:
    Status Message:  mysql-instance created with restore-job
```

## Задание (*) 2
1. Добавляем метод change_password :
```
@kopf.on.field('otus.homework', 'v1', 'mysqls', field='spec.password')
def change_password(body, old, new, **kwargs):
    name = body['metadata']['name']
    image = body['spec']['image']
    database = body['spec']['database']

    if old and new: # если есть старый и новый пароли, проводим смену пароля
        api = kubernetes.client.BatchV1Api()
        password_job = render_template('password-job.yml.j2', { # создаём описание job из шаблона
            'name': name,
            'image': image,
            'old': old,
            'new': new,
            'database': database})

        try:
            api = kubernetes.client.BatchV1Api()
            api.delete_namespaced_job('password-' + name + '-job', 'default', propagation_policy='Foreground') # удаляем предыдущий job со сменой пароля
        except kubernetes.client.rest.ApiException:
            pass

        time.sleep(1)
        api.create_namespaced_job('default', password_job) # создаём новый job со сменой пароля
```
2. изменяем пароль в **CR** на **password1**
3. применяем новое описание **CR** командами :
```
kubectl apply -f deploy/cr.yaml
mysql.otus.homework/mysql-instance configured
``` 
 4. дожидаемся окончания восстановления командой **kubectl get jobs.batch password-mysql-instance-job** :
 ```
 NAME                          COMPLETIONS   DURATION   AGE
password-mysql-instance-job   1/1           5s         119m
```
5. проверяем содержимое таблицы командами :
```
export MYSQLPOD=$(kubectl get pods -l app=mysql-instance -o jsonpath="{.items[*].metadata.name}")
kubectl exec -it $MYSQLPOD -- mysql -potuspassword1 -e "select * from test;" otus-database
```
результат :
```
+----+-------------+
| id | name        |
+----+-------------+
|  1 | some data   |
|  2 | some data-2 |
```

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
