### PR TITLE
kubernetes-storage

### DIFF
--- a/kubernetes-storage/hw/csi-pod.yaml
+++ b/kubernetes-storage/hw/csi-pod.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: storage-pod
+spec:
+  containers:
+  - name: storage-pod
+    image: ubuntu
+    command: ["/bin/bash", "-ec", "while :; do sleep 2; done"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: storage-pvc

--- a/kubernetes-storage/hw/csi-pvc.yaml
+++ b/kubernetes-storage/hw/csi-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: storage-pvc
+spec:
+  storageClassName: csi-hostpath-sc
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/iscsi/iscsi-pod.yaml
+++ b/kubernetes-storage/iscsi/iscsi-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: iscsi-pv-pod
+  name: iscsi-pv-pod
+spec:
+  containers:
+  - name: iscsi-pv-pod-alpine
+    image: alpine
+    command: ["sleep", "60000"]
+    volumeMounts:
+    - name: iscsi-vol1
+      mountPath: /opt
+      readOnly: false
+  volumes:
+  - name: iscsi-vol1
+    persistentVolumeClaim:
+      claimName: iscsi-pvc

--- a/kubernetes-storage/iscsi/iscsi-pv.yaml
+++ b/kubernetes-storage/iscsi/iscsi-pv.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: iscsi-pv
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  iscsi:
+     targetPortal: 10.1.0.23
+     iqn: iqn.2024-03.example.com:lun1
+     lun: 0
+     fsType: 'ext4'
+     readOnly: false

--- a/kubernetes-storage/iscsi/iscsi-pvc.yaml
+++ b/kubernetes-storage/iscsi/iscsi-pvc.yaml
@@ -1,0 +1,10 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: iscsi-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes-storage/iscsi/iscsi-sc.yaml
+++ b/kubernetes-storage/iscsi/iscsi-sc.yaml
@@ -1,0 +1,35 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: iscsi-targetd-vg-targetd
+provisioner: iscsi-targetd
+parameters:
+# this id where the iscsi server is running
+  targetPortal: 10.1.0.23:3260
+
+# if you are using multipath, you can specify additional IPs here, default empty
+# portals: 192.168.99.101:3260,192.168.99.102:3260
+
+# this is the iscsi server iqn
+  iqn: iqn.2024-03.example.com:lun1
+
+# this is the iscsi interface to be used, the default is default
+# iscsiInterface: default
+
+# this must be on eof the volume groups condifgured in targed.yaml, the default is vg-targetd
+# volumeGroup: vg-targetd
+
+# this is a comma separated list of initiators that will be give access to the created volumes, they must correspond to what you have configured in your nodes.
+  initiators: iqn.2024-03.example.com:worker
+
+# whether or not to use chap authentication for discovery operations
+  chapAuthDiscovery: "false"
+
+# whether or not to use chap authentication for session operations
+  chapAuthSession: "false"
+
+# This is the filesystem you want your volume to be formatted with, default xfs
+  fsType: ext4
+
+# Whether the volume should be mounted in readonly mode, default false
+# readonly: false


### PR DESCRIPTION
# Выполнено ДЗ № 12

 - [x] Основное ДЗ
 - [x] Задание со *

```shell
git clone https://github.com/kubernetes-csi/csi-driver-host-path.git
./csi-driver-host-path/deploy/kubernetes-1.27/deploy.sh
kubectl apply -f https://raw.githubusercontent.com/kubernetes-csi/csi-driver-host-path/master/examples/csi-storageclass.yaml
kubectl apply -f csi-pvc.yaml
kubectl apply -f csi-pod.yaml
```

# ISCSI
Установил кластер с одной рабочей нодой и одну виртуальную машину (всё на Ubuntu 20)

Настроил Target:
```
sudo dd if=/dev/zero of=/media/lun0.img bs=1M count=2048
sudo apt -y install tgt

cat /etc/tgt/conf.d/iscsi.conf
<target iqn.2024-03.eugen.com:lun1>
     backing-store /media/lun0.img
     initiator-address 192.168.1.20
    incominguser iscsi-user password
     outgoinguser iscsi-target secretpass
</target>

sudo tgtadm --mode target --op show
Target 1: iqn.2024-03.eugen.com:lun1
    System information:
        Driver: iscsi
        State: ready
    I_T nexus information:
    LUN information:
        LUN: 0
            Type: controller
            SCSI ID: IET     00010000
            SCSI SN: beaf10
            Size: 0 MB, Block size: 1
            Online: Yes
            Removable media: No
            Prevent removal: No
            Readonly: No
            SWP: No
            Thin-provisioning: No
            Backing store type: null
            Backing store path: None
            Backing store flags: 
        LUN: 1
            Type: disk
            SCSI ID: IET     00010001
            SCSI SN: beaf11
            Size: 2147 MB, Block size: 512
            Online: Yes
            Removable media: No
            Prevent removal: No
            Readonly: No
            SWP: No
            Thin-provisioning: No
            Backing store type: rdwr
            Backing store path: /media/lun0.img
            Backing store flags: 
    Account information:
        iscsi-user
        iscsi-target (outgoing)
    ACL information:
        192.168.1.20
Target 2: iqn.2024-03.example.com:lun1
    System information:
        Driver: iscsi
        State: ready
    I_T nexus information:
        I_T nexus: 1
            Initiator: iqn.2024-03.example.com:worker alias: cl1i7d5g6p4edkaaiv5m-idad
            Connection: 0
                IP Address: 10.1.0.30
    LUN information:
        LUN: 0
            Type: controller
            SCSI ID: IET     00020000
            SCSI SN: beaf20
            Size: 0 MB, Block size: 1
            Online: Yes
            Removable media: No
            Prevent removal: No
            Readonly: No
            SWP: No
            Thin-provisioning: No
            Backing store type: null
            Backing store path: None
            Backing store flags: 
    Account information:
        user
    ACL information:
        10.1.0.30

```

Настроил инициатора:
```
sudo echo "node.session.auth.username = user" >> /etc/iscsi/nodes/iqn.2024-03.example.com:lun1/10.1.0.23,3260,1/default
sudo echo "node.session.auth.password = secretpass" >> /etc/iscsi/nodes/iqn.2024-03.example.com:lun1/10.1.0.23,3260,1/default

sudo iscsiadm -m node --login
Logging in to [iface: default, target: iqn.2024-03.example.com:lun1, portal: 10.1.0.23,3260] (multiple)

```

Запустил приложение:
```
kubernetes apply -f kubernetes-storage/iscsi/
kubernetes exec -it iscsi-pv-pod -- /bin/sh
echo "foo" > /opt/bar.txt
```

Сделал snapshot на виртуалке, удалил приложение, восстановил snapshot, запустил приложение, данные на месте:
```
kubernetes apply -f kubernetes-storage/iscsi/
kubernetes exec -it iscsi-pv-pod -- /bin/sh
 cat /opt/bar.txt 
foo
```



## PR checklist:
 - [x] Выставлен label с темой домашнего задания
