### PR TITLE
kubernetes-debug

### DIFF
--- a/kubernetes-debug/kit/operator.yaml
+++ b/kubernetes-debug/kit/operator.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: netperf-pod
+  labels:
+    app: netperf-pod
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: netperf-pod
+  template:
+    metadata:
+      labels:
+        app: netperf-pod
+    spec:
+      containers:
+      - name: netperf-pod
+        image: leannet/k8s-netperf:latest
+        ports:
+        - containerPort: 5001
+        - containerPort: 8079
+        - containerPort: 8080
+        - containerPort: 8081
+        - containerPort: 12865
+        #imagePullPolicy: Never
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: netperf-server
+  labels:
+    name: netperf-server
+    app: netperf
+spec:
+  ports:
+    # the port that this service should serve on
+  - name: iperf-tcp
+    protocol: TCP
+    port: 5001
+    targetPort: 5001
+  - name: iperf-udp
+    protocol: UDP
+    port: 5001
+    targetPort: 5001
+  - name: fortio-http
+    protocol: TCP
+    port: 8080
+    targetPort: 8080
+  - name: fortio-proxy
+    protocol: TCP
+    port: 8081
+    targetPort: 8081
+  - name: fortio-grpc
+    protocol: TCP
+    port: 8079
+    targetPort: 8079
+  selector:
+    app: netperf-pod
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netperf-pod
+  labels:
+    app: netperf-pod
+spec:
+  selector:
+    matchLabels:
+      app: netperf-pod
+  template:
+    metadata:
+      labels:
+        app: netperf-pod
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: netperf-pod
+        image: leannet/k8s-netperf:latest
+        ports:
+        - containerPort: 5001
+        - containerPort: 8079
+        - containerPort: 8080
+        - containerPort: 8081
+        - containerPort: 12865
+
+---
+
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: netperf-host
+  labels:
+    app: netperf-host
+spec:
+  selector:
+    matchLabels:
+      app: netperf-host
+  template:
+    metadata:
+      labels:
+        app: netperf-host
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: netperf-host
+        image: leannet/k8s-netperf:latest
+        ports:
+        - containerPort: 5001
+        - containerPort: 8079
+        - containerPort: 8080
+        - containerPort: 8081
+        - containerPort: 12865

--- a/kubernetes-debug/kit/runNetPerfTest.pl
+++ b/kubernetes-debug/kit/runNetPerfTest.pl
@@ -1,0 +1,537 @@
+#!/usr/bin/perl -w
+
+###################################################
+### This script runs several kubectl commands   ###
+### in order to measure the network performance ###
+### beetween K8s nodes, pods and services       ###
+### in various scenarios.                       ###
+###                                             ###
+### Requires JSON::Parse, so install it by:     ###
+### sudo perl -MCPAN -e 'install JSON::Parse'   ###
+###                                             ###
+### If make was not OK (e.g. on cloud image),   ###
+### than you also need to install make by       ### 
+### sudo apt install build-essentials           ###
+###                                             ###
+### Written by Megyo on 15. May 2018            ###
+### Last modified on 21. Jan 2019               ###
+###################################################
+
+use strict;
+use JSON::Parse ':all';
+
+#maximum number of measurements in different types
+my $numberOfLocalhostMeasurements = 2;
+my $numberOfInterNodeMeasurements = 4;
+my $iperfTime = 2;
+
+my $netperfRequestPacketSize = 32;
+my $netperfResponsePacketSize = 1024;
+
+#hash to store every data on Nodes
+my %nodes = ();
+
+#hash to store every data on NetPerf Pods
+my %pods = ();
+
+#hash to store every data on Netperf Service
+my %services = ();
+
+#simple IP address regular expression
+my $IPregexp = '\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}';
+
+#reading ARGV for --nobaseline flag
+my $nobaseline = 0;
+if ((defined($ARGV[0])) and ($ARGV[0] =~ /--nobaseline/)) {
+	$nobaseline = 1;
+}
+print STDERR "No Baseline flag is: $nobaseline\n";
+
+#reading Node, POD and Service information from Kubernetes
+&getKubernetesInfo();
+
+#run Iperf on ceratain nodes (PODs in hostnetworking mode) to localhost
+my @randArray = randomKeysFromHash($numberOfLocalhostMeasurements,%nodes);
+foreach my $node (@randArray) {
+	last if ($nobaseline);
+ 	my $podName = $nodes{$node}->{'HostNetPerf'};
+	my $targetIP = $nodes{$node}->{'IPaddress'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "Localhost Iperf throughput test on Node $node: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_RR test on Node $node (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_CRR test on Node $node (HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "Localhost Fortio using HTTP 1.0 on Node $node: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "Localhost Fortio using HTTP 1.1 on Node $node: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "Localhost Fortio using GRPC on Node $node: $fortioGRPC\n"; 	
+}
+
+#run Iperf on ceratain PODs as localhost
+@randArray = randomKeysFromHash($numberOfLocalhostMeasurements,%pods);
+foreach my $podName (@randArray) {
+	last if ($nobaseline);
+	my $targetIP = $pods{$podName}->{'IPaddress'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "Localhost Iperf throughput test on POD $podName: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_RR test on POD $podName (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_CRR test on POD $podName (HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "Localhost Fortio using HTTP 1.0 on POD $podName: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "Localhost Fortio using HTTP 1.1 on POD $podName: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "Localhost Fortio using GRPC on POD $podName: $fortioGRPC\n"; 	
+}
+
+#run Iperf between ceratain PODs and their host (use the same random POD array to the previous case)
+foreach my $podName (@randArray) {
+	last if ($nobaseline);
+	my $targetIP = $pods{$podName}->{'NodeIP'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "Localhost Iperf throughput test between POD $podName and it's Node: $pods{$podName}->{NodeName}: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_RR test between POD $podName and it's Node: $pods{$podName}->{NodeName} (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_CRR test between POD $podName and it's Node: $pods{$podName}->{NodeName}(HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "Localhost Fortio using HTTP 1.0 between POD $podName and it's Node: $pods{$podName}->{NodeName}: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "Localhost Fortio using HTTP 1.1 between POD $podName and it's Node: $pods{$podName}->{NodeName}: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "Localhost Fortio using GRPC between POD $podName and it's Node: $pods{$podName}->{NodeName}: $fortioGRPC\n"; 	
+}
+
+#run Iperf between PODs located on the same host
+my %randHash = randomPodPairsOnSameNode($numberOfLocalhostMeasurements);
+foreach my $podName (keys %randHash) {
+	my $targetIP = $pods{$randHash{$podName}}->{'IPaddress'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "Localhost Iperf throughput test between POD $podName and POD $randHash{$podName}: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_RR test between POD $podName and POD $randHash{$podName} (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "Localhost NetPerf TCP_CRR test between POD $podName and POD $randHash{$podName}(HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "Localhost Fortio using HTTP 1.0 between POD $podName and POD $randHash{$podName}: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "Localhost Fortio using HTTP 1.1 between POD $podName and POD $randHash{$podName}: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "Localhost Fortio using GRPC between POD $podName and POD $randHash{$podName}: $fortioGRPC\n"; 	
+}
+
+#if only have one node, than exit
+exit if (scalar(keys %nodes) < 2);
+
+#run Iperf between Nodes to see maximum internode capacity
+my %randNodePairs = randomNodePairs($numberOfInterNodeMeasurements);
+foreach my $node (keys %randNodePairs) {
+	last if ($nobaseline);
+	my $podName = $nodes{$node}->{'HostNetPerf'};
+	my $targetIP = $nodes{$randNodePairs{$node}}->{'IPaddress'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "InterNode Iperf throughput test between Node $node and Node $randNodePairs{$node}: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_RR test between Node $node and Node $randNodePairs{$node} (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_CRR test between Node $node and Node $randNodePairs{$node}(HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "InterNode Fortio using HTTP 1.0 between Node $node and Node $randNodePairs{$node}: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "InterNode Fortio using HTTP 1.1 between Node $node and Node $randNodePairs{$node}: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "InterNode Fortio using GRPC between Node $node and Node $randNodePairs{$node}: $fortioGRPC\n"; 	
+}
+
+#run Iperf between PODs running on differnet nodes to see performance degradation
+%randHash = randomPodsOnDiffernetNodes(%randNodePairs);
+foreach my $podName (keys %randHash) {
+ 	my $targetIP = $pods{$randHash{$podName}}->{'IPaddress'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "InterNode Iperf throughput test between POD $podName and POD $randHash{$podName}: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_RR test between POD $podName and POD $randHash{$podName} (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_CRR test between POD $podName and POD $randHash{$podName}(HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "InterNode Fortio using HTTP 1.0 between POD $podName and POD $randHash{$podName}: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "InterNode Fortio using HTTP 1.1 between POD $podName and POD $randHash{$podName}: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "InterNode Fortio using GRPC between POD $podName and POD $randHash{$podName}: $fortioGRPC\n"; 	
+
+}
+
+#run Iperf between a POD and another node (not the host of the POD)
+foreach my $podName (keys %randHash) {
+	last if ($nobaseline);
+ 	my $targetIP = $pods{$randHash{$podName}}->{'NodeIP'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "InterNode Iperf throughput test between POD $podName and Node $pods{$randHash{$podName}}->{NodeName}: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_RR test between POD $podName and Node $pods{$randHash{$podName}}->{NodeName} (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_CRR test between POD $podName and Node $pods{$randHash{$podName}}->{NodeName}(HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "InterNode Fortio using HTTP 1.0 between POD $podName and Node $pods{$randHash{$podName}}->{NodeName}: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "InterNode Fortio using HTTP 1.1 between POD $podName and Node $pods{$randHash{$podName}}->{NodeName}: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "InterNode Fortio using GRPC between POD $podName and Node $pods{$randHash{$podName}}->{NodeName}: $fortioGRPC\n"; 	
+}
+
+#run Iperf a node and a POD located on a different node to see difference between asymetric routes
+foreach my $pod (keys %randHash) {
+	last if ($nobaseline);
+ 	my $podName = $nodes{$pods{$randHash{$pod}}->{'NodeName'}}->{'HostNetPerf'};
+	my $targetIP = $pods{$pod}->{'IPaddress'};
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "InterNode Iperf throughput test between Node $pods{$randHash{$pod}}->{NodeName} and POD $pod: $iperf\n"; 
+
+	my $netperfRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_RR', 'P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_RR test between Node $pods{$randHash{$pod}}->{NodeName} and POD $pod (lantency 50,90 and 99 percentiles in us and DB like transaction rate): $netperfRR\n"; 
+
+	my $netperfCRR = &runNetperf($podName, $targetIP, $iperfTime, 'TCP_CRR', 'THROUGHPUT,THROUGHPUT_UNITS');
+	print "InterNode NetPerf TCP_CRR test between Node $pods{$randHash{$pod}}->{NodeName} and POD $pod(HTTP API like transaction rate): $netperfCRR\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "InterNode Fortio using HTTP 1.0 between Node $pods{$randHash{$pod}}->{NodeName} and POD $pod: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "InterNode Fortio using HTTP 1.1 between Node $pods{$randHash{$pod}}->{NodeName} and POD $pod: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "InterNode Fortio using GRPC between Node $pods{$randHash{$pod}}->{NodeName} and POD $pod: $fortioGRPC\n"; 	
+}
+
+#run Iperf between PODs and Service IP to see kube-proxy performance
+#we dont't run NetPerf since its using dinamically allocated port numebers for data exchange, which is not supported in Kubernetes Services abstraction
+my $serviceIP = $services{'netperf-server'}->{'clusterIP'};
+foreach my $podName (keys %randHash) {
+	my $targetIP = $serviceIP;
+	
+	my $iperf = &runIperf($podName, $targetIP, $iperfTime);
+	print "ClusterIP based Iperf throughput test between POD $podName and netperf-server service with IP $serviceIP: $iperf\n"; 
+
+	my $fortioHTTP10 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1 -http1.0');
+	print "ClusterIP based Fortio using HTTP 1.0 between POD $podName and netperf-server service with IP $serviceIP: $fortioHTTP10\n"; 
+	
+	my $fortioHTTP11 = &runFortio($podName, $targetIP, $iperfTime, '-qps 0 -c 1');
+	print "ClusterIP based Fortio using HTTP 1.1 between POD $podName and netperf-server service with IP $serviceIP: $fortioHTTP11\n"; 
+
+	my $fortioGRPC = &runFortio($podName, $targetIP,, $iperfTime, '-qps 0 -c 1 -grpc -ping');
+	print "ClusterIP based Fortio using GRPC between POD $podName and netperf-server service with IP $serviceIP: $fortioGRPC\n"; 	
+}
+
+sub runIperf {
+	my ($pod, $serverIP, $time) = @_;
+    print STDERR "running command: kubectl exec -it $pod -- iperf -c $serverIP -i 1 -t $time \n";
+	open(IPERF, "kubectl exec -it $pod -- iperf -c $serverIP -i 1 -t $time | ");
+	my $lastLine = '';
+	while (<IPERF>) {
+		print STDERR $_;
+		$lastLine = $_;
+	}
+	close(IPERF);
+	chomp($lastLine);
+	$lastLine =~ s/.*?(\d+\.\d+ .bits\/sec).*/$1/;
+	return $lastLine;
+}
+
+sub runNetperf {
+	my ($pod, $serverIP, $time, $type, $format) = @_;
+	my $lastLine = '';
+    print STDERR "running command: kubectl exec -it $pod -- netperf -H $serverIP -l $time -P 1 -t $type -- -r $netperfRequestPacketSize,$netperfResponsePacketSize -o $format \n";
+	open(NETPERF, "kubectl exec -it $pod -- netperf -H $serverIP -l $time -P 1 -t $type -- -r $netperfRequestPacketSize,$netperfResponsePacketSize -o $format | ");
+	while (<NETPERF>) {
+		print STDERR $_;
+		$lastLine = $_;
+	}
+	chomp($lastLine);
+	close(NETPERF);
+	return $lastLine;
+}
+
+sub runFortio {
+	my ($pod, $serverIP, $time, $flags) = @_;
+	my $lastLine = '';
+	my $outputstring = '';
+	my $port = '';
+	$port = ':8080' unless ($flags =~ /grpc/);
+    print STDERR "running command: kubectl exec -it $pod -- fortio load $flags -t ${time}s $serverIP$port \n";
+	open(FORTIO, "kubectl exec -it $pod -- fortio load $flags -t ${time}s $serverIP$port | ");
+	while (my $line = <FORTIO>) {
+		print STDERR $line;
+		$line =~ s/\n|\r//g;
+		$line =~ s/[^0-9a-zA-z %.,]//g;
+		$line =~ s/\t/ /g;
+		if ($line =~ /target 50% (.*)/) {
+			$outputstring .= $1 . ', ';
+		}
+		elsif ($line =~ /target 90% (.*)/) {
+			$outputstring .= $1 . ', ';
+		}
+		elsif ($line =~ /target 99% (.*)/) {
+			$outputstring .= $1 . ', ';
+		}
+		$lastLine = $line;
+	}
+	$lastLine =~ s/^.*,//;
+	$outputstring .= $lastLine;
+	close(FORTIO);
+	return $outputstring;
+}
+
+sub randomKeysFromHash {
+    my $number = shift;
+    my %hash = @_; 
+    my @randomList = ();
+	
+    while (($number > 0) and (scalar(keys %hash) > 0)) {
+		my $randKey = (keys %hash)[rand keys %hash];
+		push @randomList, $randKey;
+		delete $hash{$randKey};
+		$number--;
+	}
+	
+    return @randomList;
+}
+
+sub randomPodPairsOnSameNode {
+    my $number = shift;
+    my %hash = (); 
+    
+    foreach my $node (keys %nodes) {
+		my @tmp = @{$nodes{$node}->{'pods'}};
+		while (($number > 0) and (scalar(@tmp) > 1)) {
+			$hash{$tmp[0]} = $tmp[1];
+            #print "\t\t$tmp->[0] ---> $tmp->[1]\n";
+			shift @tmp;
+			$number--;
+		}
+	}
+		
+    return %hash;
+}
+
+sub randomNodePairs {
+    my $number = shift;
+    my %hash = (); 
+    
+	my @tmp = keys %nodes;
+	
+    return %hash if (scalar(@tmp) < 2);
+	
+	if (scalar(@tmp) == 2) {
+		$hash{$tmp[0]} = $tmp[1];
+		$hash{$tmp[1]} = $tmp[0];
+		return %hash;
+	}
+
+	if (scalar(@tmp) == 3) {
+		$hash{$tmp[0]} = $tmp[1];
+		$hash{$tmp[1]} = $tmp[0];
+		$hash{$tmp[1]} = $tmp[2];
+		$hash{$tmp[0]} = $tmp[2];
+		return %hash;
+	}
+	
+	if (scalar(@tmp) == 4) {
+		$hash{$tmp[0]} = $tmp[1];
+		$hash{$tmp[0]} = $tmp[2];
+		$hash{$tmp[0]} = $tmp[3];
+		$hash{$tmp[1]} = $tmp[2];
+		$hash{$tmp[2]} = $tmp[3];
+		return %hash;
+	}
+
+	while (($number > 0) and (scalar(@tmp) > 1)) {
+		$hash{$tmp[0]} = $tmp[1];
+		shift @tmp;
+		$number--;
+	}
+		
+    return %hash;
+}
+
+
+sub randomPodsOnDiffernetNodes {
+    my %nodePairs = @_;
+    my %hash = ();
+
+	foreach my $nodeA (keys %nodePairs) {
+		my @tmpA = @{$nodes{$nodeA}->{'pods'}};
+		my @tmpB = @{$nodes{$nodePairs{$nodeA}}->{'pods'}};
+		
+		my $podA = $tmpA[rand @tmpA];
+		my $podB = $tmpB[rand @tmpB];
+		$hash{$podA} = $podB;
+	}
+
+	return %hash;
+}
+
+sub getKubernetesInfo {
+
+	#get name of all nodes in the cluster
+	my $allNodes = `kubectl get nodes -o name`;
+	foreach (split("\n", $allNodes)) {
+		#this will be the temporary variable to store all relevant Node data
+		my %tmp = ();
+		
+		#add array for future POD information
+		my @podsOnThisNode = ();
+		$tmp{'pods'} = \@podsOnThisNode;
+			
+		$_ =~ s/node\///;
+		print STDERR "Node: $_\n";
+		
+		#get all the information on this particular Nodes
+		my $res = `kubectl describe node $_`;
+		foreach my $line (split("\n", $res)) {
+			#get IPaddress of the Node
+			if ($line =~ /InternalIP:.*?($IPregexp)/) {
+				$tmp{'IPaddress'} = $1;
+			}
+			
+			#get PodCIDR of the Node 
+			if ($line =~ /PodCIDR:.*?($IPregexp\/\d+)/) {
+				$tmp{'PodCIDR'} = $1;
+			}
+			
+		}
+		$nodes{$_} = \%tmp;
+	}
+
+
+	#get name of all pods in the cluster
+	my $allPods = `kubectl get pods -o=custom-columns=NAME:.metadata.name,NAMESPACE:.metadata.namespace | grep netperf`;
+	foreach (split("\n", $allPods)) {
+		#next if ($_ =~ /NAMESPACE/); #just skip the first header line
+		
+		#this will be the temporary variable to store all relevant POD data
+		my %tmp = ();
+		
+		my ($name, $namespace) = split(/ +/, $_);
+		print STDERR "Pod: $name  in  $namespace \n";
+		$tmp{'namespace'} = $namespace;
+		
+		#get all the information on this particular Nodes
+		my $res = `kubectl describe pod $name --namespace=$namespace`;
+		foreach my $line (split("\n", $res)) {
+			#get IPaddress of the POD
+			if ($line =~ /IP:.*?($IPregexp)/) {
+				$tmp{'IPaddress'} = $1;
+			}
+			
+			#get the Node that the POD is running on
+			if ($line =~ /Node: +(.*?)\/($IPregexp)/) {
+				$tmp{'NodeName'} = $1;
+				$tmp{'NodeIP'} = $2;            
+			}
+		}
+		#if this POD runs in host mode, we add it to the node
+		if ($tmp{'IPaddress'} eq $tmp{'NodeIP'}) {
+			$nodes{$tmp{'NodeName'}}->{'HostNetPerf'} = $name;
+		}	
+		#adding the same POD to the Node's list and to the POD list
+		else {
+			push @{$nodes{$tmp{'NodeName'}}->{'pods'}}, $name;
+			$pods{$name} = \%tmp;
+		}	
+		
+	}
+
+	#get all info on NetPerf service
+	my $allServices = `kubectl get services --all-namespaces -o wide | grep netperf`;
+	foreach (split("\n", $allServices)) {
+		next if ($_ =~ /NAMESPACE/); #just skip the first header line
+		
+		#this will be the temporary variable to store all relevant POD data
+		my %tmp = ();
+		
+		my @podBackends = ();
+		
+		my ($namespace, $name, $type, $clusterIP, $externalIP, $port, $age, $selector) = split(/ +/, $_);
+		print STDERR "service: $name  in  $namespace IP=$clusterIP $externalIP $selector \n";
+		$tmp{'namespace'} = $namespace;
+		$tmp{'type'} = $type;
+		$tmp{'clusterIP'} = $clusterIP;
+		$tmp{'externalIP'} = $externalIP;
+		$tmp{'selector'} = $selector;
+		
+		
+		#get all the POD backends for this service
+		my $res = `kubectl get pods -l $selector --all-namespaces -o name`;
+		foreach my $line (split("\n", $res)) {
+			$line =~ s/pods\///;
+			push @podBackends, $line;
+		}
+		$tmp{'podBackends'} = \@podBackends;
+			
+		$services{$name} = \%tmp;
+	}
+
+	#in order to get all the ports for the services we do a query in JSON
+	my $json = `kubectl get services --all-namespaces -o json`;
+	my $hash = parse_json ($json);
+	#print ref $hash, "\n";
+
+	foreach my $svc (@{$hash->{'items'}}) {
+		#print $svc->{'metadata'}->{'name'}, '   ', $svc->{'spec'}->{'ports'}, "\n";
+		next unless (defined($services{$svc->{'metadata'}->{'name'}}));
+		$services{$svc->{'metadata'}->{'name'}}->{'ports'} = $svc->{'spec'}->{'ports'};
+	}
+
+	print STDERR join(' ',%nodes),"\n";
+	print STDERR join(' ',%pods),"\n";
+	print STDERR join(' ',%services),"\n";
+}


### PR DESCRIPTION
# Выполнено ДЗ №

 - [x] Основное ДЗ
 - [x] Задание со *

Отладим контейнер с Nginx:
```
kubectl run ephemeral-nginx --image=nginx --restart=Never
kubectl debug -it ephemeral-nginx --image=alpine:latest --target=ephemeral-nginx
# apk --update add strace
# strace ls
execve("/bin/ls", ["ls"], 0x7fffd5931f00 /* 42 vars */) = 0
arch_prctl(ARCH_SET_FS, 0x7fe924021b08) = 0
set_tid_address(0x7fe924021f70)         = 58
brk(NULL)                               = 0x5555b0e67000
brk(0x5555b0e69000)                     = 0x5555b0e69000
mmap(0x5555b0e67000, 4096, PROT_NONE, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0) = 0x5555b0e67000
mprotect(0x7fe92401e000, 4096, PROT_READ) = 0
mprotect(0x5555b0b8b000, 16384, PROT_READ) = 0
getuid()                                = 0
ioctl(0, TIOCGWINSZ, {ws_row=14, ws_col=228, ws_xpixel=0, ws_ypixel=0}) = 0
ioctl(1, TIOCGWINSZ, {ws_row=14, ws_col=228, ws_xpixel=0, ws_ypixel=0}) = 0
ioctl(1, TIOCGWINSZ, {ws_row=14, ws_col=228, ws_xpixel=0, ws_ypixel=0}) = 0
stat(".", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
open(".", O_RDONLY|O_LARGEFILE|O_CLOEXEC|O_DIRECTORY) = 3
fcntl(3, F_SETFD, FD_CLOEXEC)           = 0
mmap(NULL, 8192, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0) = 0x7fe923f7e000
getdents64(3, 0x7fe923f7e038 /* 19 entries */, 2048) = 464
lstat("./home", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./bin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./mnt", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./run", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./proc", {st_mode=S_IFDIR|0555, st_size=0, ...}) = 0
lstat("./dev", {st_mode=S_IFDIR|0755, st_size=380, ...}) = 0
lstat("./usr", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./root", {st_mode=S_IFDIR|0700, st_size=4096, ...}) = 0
lstat("./sys", {st_mode=S_IFDIR|0555, st_size=0, ...}) = 0
lstat("./sbin", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./tmp", {st_mode=S_IFDIR|S_ISVTX|0777, st_size=4096, ...}) = 0
lstat("./srv", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./etc", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./media", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./lib", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./var", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
lstat("./opt", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
getdents64(3, 0x7fe923f7e038 /* 0 entries */, 2048) = 0
close(3)                                = 0
munmap(0x7fe923f7e000, 8192)            = 0
ioctl(1, TIOCGWINSZ, {ws_row=14, ws_col=228, ws_xpixel=0, ws_ypixel=0}) = 0
writev(1, [{iov_base="\33[1;34mbin\33[m    \33[1;34mdev\33[m  "..., iov_len=285}, {iov_base="\n", iov_len=1}], 2bin    dev    etc    home   lib    media  mnt    opt    proc   root   run    sbin   srv    sys    tmp    usr    var
) = 286
exit_group(0)                           = ?
+++ exited with 0 +++
/ # 

```

Запустим сетевую отладку. После длительного поиска найден рабочий вариант:
```
kubectl apply -f ./kit/operator.yaml : 
perl runNetPerfTest.pl
No Baseline flag is: 0
Node: cl1okg2s4bkhm349qguq-ahok
Pod: netperf-host-x55k8  in  default 
Pod: netperf-pod-cf9f7db8f-mshfw  in  default 
Pod: netperf-pod-cf9f7db8f-phhbh  in  default 
Pod: netperf-pod-ndj8s  in  default 
service: netperf-server  in  default IP=10.96.135.243 <none> app=netperf-pod 
cl1okg2s4bkhm349qguq-ahok HASH(0x557242be8e68)
netperf-pod-cf9f7db8f-mshfw HASH(0x557242be91f8) netperf-pod-ndj8s HASH(0x557242a7d7a0) netperf-pod-cf9f7db8f-phhbh HASH(0x557242a595a8)
netperf-server HASH(0x557242bfeb50)
running command: kubectl exec -it netperf-host-x55k8 -- iperf -c 10.1.0.13 -i 1 -t 2 
------------------------------------------------------------
Client connecting to 10.1.0.13, TCP port 5001
TCP window size: 2.50 MByte (default)
------------------------------------------------------------
[  3] local 10.1.0.13 port 40172 connected with 10.1.0.13 port 5001
[ ID] Interval       Transfer     Bandwidth
[  3]  0.0- 1.0 sec  4.86 GBytes  41.8 Gbits/sec
[  3]  1.0- 2.0 sec  4.85 GBytes  41.7 Gbits/sec
[  3]  0.0- 2.0 sec  9.71 GBytes  41.7 Gbits/sec
Localhost Iperf throughput test on Node cl1okg2s4bkhm349qguq-ahok: 41.7 Gbits/sec
running command: kubectl exec -it netperf-host-x55k8 -- netperf -H 10.1.0.13 -l 2 -P 1 -t TCP_RR -- -r 32,1024 -o P50_LATENCY,P90_LATENCY,P99_LATENCY,THROUGHPUT,THROUGHPUT_UNITS 
MIGRATED TCP REQUEST/RESPONSE TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.1.0.13 (10.1.0.) port 0 AF_INET : first burst 0
50th Percentile Latency Microseconds,90th Percentile Latency Microseconds,99th Percentile Latency Microseconds,Throughput,Throughput Units
25,29,36,39796.67,Trans/s
Localhost NetPerf TCP_RR test on Node cl1okg2s4bkhm349qguq-ahok (lantency 50,90 and 99 percentiles in us and DB like transaction rate): 25,29,36,39796.67,Trans/s
running command: kubectl exec -it netperf-host-x55k8 -- netperf -H 10.1.0.13 -l 2 -P 1 -t TCP_CRR -- -r 32,1024 -o THROUGHPUT,THROUGHPUT_UNITS 
MIGRATED TCP Connect/Request/Response TEST from 0.0.0.0 (0.0.0.0) port 0 AF_INET to 10.1.0.13 (10.1.0.) port 0 AF_INET
Throughput,Throughput Units
16482.06,Trans/s
Localhost NetPerf TCP_CRR test on Node cl1okg2s4bkhm349qguq-ahok (HTTP API like transaction rate): 16482.06,Trans/s
running command: kubectl exec -it netperf-host-x55k8 -- fortio load -qps 0 -c 1 -http1.0 -t 2s 10.1.0.13:8080 
Fortio 1.3.0 running at 0 queries per second, 4->4 procs, for 2s: 10.1.0.13:8080
23:57:07 I httprunner.go:82> Starting http test for 10.1.0.13:8080 with 1 threads at -1.0 qps
23:57:07 W http_client.go:142> Assuming http:// on missing scheme for '10.1.0.13:8080'
Starting at max qps with 1 thread(s) [gomax 4] for 2s
23:57:09 I periodic.go:533> T000 ended after 2.000022678s : 13065 calls. qps=6532.425928822393
Ended after 2.000069466s : 13065 calls. qps=6532.3
Aggregated Function Time : count 13065 avg 0.00015283108 +/- 2.852e-05 min 0.000107586 max 0.00154359 sum 1.99673805
# range, mid point, percentile, count
>= 0.000107586 <= 0.001 , 0.000553793 , 99.98, 13063
> 0.001 <= 0.00154359 , 0.0012718 , 100.00, 2
# target 50% 0.000553827
# target 75% 0.000776982
# target 90% 0.000910875
# target 99% 0.00099121
# target 99.9% 0.000999244
Sockets used: 13066 (for perfect keepalive, would be 1)
Code 200 : 13065 (100.0 %)
Response Header Sizes : count 13065 avg 0 +/- 0 min 0 max 0 sum 0
Response Body/Total Sizes : count 13065 avg 75 +/- 0 min 75 max 75 sum 979875
All done 13065 calls (plus 1 warmup) 0.153 ms avg, 6532.3 qps
Localhost Fortio using HTTP 1.0 on Node cl1okg2s4bkhm349qguq-ahok: 0.000553827, 0.000910875, 0.00099121,  6532.3 qps
running command: kubectl exec -it netperf-host-x55k8 -- fortio load -qps 0 -c 1 -t 2s 10.1.0.13:8080 
Fortio 1.3.0 running at 0 queries per second, 4->4 procs, for 2s: 10.1.0.13:8080
23:57:11 I httprunner.go:82> Starting http test for 10.1.0.13:8080 with 1 threads at -1.0 qps
23:57:11 W http_client.go:142> Assuming http:// on missing scheme for '10.1.0.13:8080'
Starting at max qps with 1 thread(s) [gomax 4] for 2s
23:57:13 I periodic.go:533> T000 ended after 2.000055211s : 30408 calls. qps=15203.580297564096
Ended after 2.000094354s : 30408 calls. qps=15203
Aggregated Function Time : count 30408 avg 6.5551632e-05 +/- 1.908e-05 min 3.4524e-05 max 0.002312369 sum 1.99329402
# range, mid point, percentile, count
>= 3.4524e-05 <= 0.001 , 0.000517262 , 100.00, 30407
> 0.002 <= 0.00231237 , 0.00215618 , 100.00, 1
# target 50% 0.000517262
# target 75% 0.000758647
# target 90% 0.000903478
# target 99% 0.000990376
# target 99.9% 0.000999066
Sockets used: 1 (for perfect keepalive, would be 1)
Code 200 : 30408 (100.0 %)
Response Header Sizes : count 30408 avg 75 +/- 0 min 75 max 75 sum 2280600
Response Body/Total Sizes : count 30408 avg 75 +/- 0 min 75 max 75 sum 2280600
All done 30408 calls (plus 1 warmup) 0.066 ms avg, 15203.3 qps
Localhost Fortio using HTTP 1.1 on Node cl1okg2s4bkhm349qguq-ahok: 0.000517262, 0.000903478, 0.000990376,  15203.3 qps
running command: kubectl exec -it netperf-host-x55k8 -- fortio load -qps 0 -c 1 -grpc -ping -t 2s 10.1.0.13 
Fortio 1.3.0 running at 0 queries per second, 4->4 procs, for 2s: 10.1.0.13
23:57:15 I grpcrunner.go:152> Starting GRPC Ping test for 10.1.0.13 with 1*1 threads at -1.0 qps
Starting at max qps with 1 thread(s) [gomax 4] for 2s
23:57:17 I periodic.go:533> T000 ended after 2.000100056s : 14681 calls. qps=7340.13278783689
Ended after 2.000153522s : 14681 calls. qps=7339.9
Aggregated Function Time : count 14681 avg 0.00013592616 +/- 6.115e-05 min 7.5425e-05 max 0.00463832 sum 1.99553191
# range, mid point, percentile, count
>= 7.5425e-05 <= 0.001 , 0.000537713 , 99.94, 14672
> 0.001 <= 0.002 , 0.0015 , 99.99, 7
> 0.002 <= 0.003 , 0.0025 , 99.99, 1
> 0.004 <= 0.00463832 , 0.00431916 , 100.00, 1
# target 50% 0.000537965
# target 75% 0.000769266
# target 90% 0.000908047
# target 99% 0.000991315
# target 99.9% 0.000999642
Ping SERVING : 14681
All done 14681 calls (plus 1 warmup) 0.136 ms avg, 7339.9 qps
Localhost Fortio using GRPC on Node cl1okg2s4bkhm349qguq-ahok: 0.000537965, 0.000908047, 0.000991315,  7339.9 qps
running command: kubectl exec -it netperf-pod-ndj8s -- iperf -c 10.112.128.16 -i 1 -t 2 
------------------------------------------------------------

```

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
